### PR TITLE
来源文件夹位置更改

### DIFF
--- a/com.ruguoapp.jike.json
+++ b/com.ruguoapp.jike.json
@@ -1,11 +1,11 @@
 {
 	"package": "com.ruguoapp.jike",
 	"recommended": true,
-	"authors": ["FoobarRogers"],
+	"authors": ["MizuhashiZ"],
 	"observers": [{
 		"description": "saved_pictures",
 		"call_media_scan": true,
-		"source": "即刻相册",
+		"source": "com.ruguoapp.jike/jikeImg",
 		"target": "Pictures/jike"
 	}]
 }


### PR DESCRIPTION
即刻 3.12.0 版本以后，应用内保存的图片的位置从 /即刻相册 变为了 /com.ruguoapp.jike/jikeImg